### PR TITLE
shorten long message because it's a bit too long

### DIFF
--- a/TcLogTest.NET/PersistingToFileSystem.cs
+++ b/TcLogTest.NET/PersistingToFileSystem.cs
@@ -81,7 +81,7 @@ namespace TcLogTest.NET
         [Fact]
         public async void Persist_long_error_message()
         {
-            string message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean aliquet orci sit amet massa placerat faucibus. Sed interdum fermentum eros. Maecenas accumsan rutrum ex, non varius orci scelerisque ac. Donec qui.";
+            string message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean aliquet orci sit amet massa placerat faucibus. Sed interdum fermentum eros. Maecenas accumsan rutrum ex, non varius orci scelerisque ac. Donec q";
             uint hRun = fixture.TcClient.CreateVariableHandle(mut + ".Persist_long_error_message_run");
             uint hData = fixture.TcClient.CreateVariableHandle(mut + ".Persist_long_error_message_data");
 


### PR DESCRIPTION
Hi @bengeisler 

I had to remove some letters from the long message because it was still a bit too long.

On the issue of the timestamps (I've not yet created a separate issue for it, sorry)
Last week I installed Twincat3 on a new machine (a VM in Virtualbox), I noticed that on that machine I did not have the issue with the timestamps, I'm not sure why.
And although the file now has a correct timestamp in the name it only contains the first message that I log. All subsequent messages are not logged and I notice the following error in TcLogCore.Error:
>Message		4/3/2023 10:30:15 899 ms   | 'Tests_Task' (351): Closing file failed. Error thrown by FB_FileClose. Consult Beckhoff InfoSys. Internal Error: 1795				

