### PR TITLE
doc: fixed doc-inline st

### DIFF
--- a/src/TcLogProj/TcLog/Logger/TcLog.TcPOU
+++ b/src/TcLogProj/TcLog/Logger/TcLog.TcPOU
@@ -77,8 +77,9 @@ AppendString REF= THIS^;]]></ST>
     <Method Name="AppendVariable" Id="{67339878-c4f6-4555-96b1-10fb6c84bab0}">
       <Declaration><![CDATA[/// Appends information about the given variable to the log string. 
 /// This method can be chained.
-/// Example: 
-/// ```
+/// Example:
+/// 
+/// ```st
 /// VAR
 ///   Logger: TcLog;
 /// 	 myInt : INT := 10;
@@ -86,6 +87,7 @@ AppendString REF= THIS^;]]></ST>
 /// END_VAR
 /// Logger.AppendVariable(myVarInfo, myInt);
 /// ```
+///
 METHOD AppendVariable : REFERENCE TO TcLog
 VAR_INPUT
   /// [VAR_INFO](https://infosys.beckhoff.com/index.php?content=../content/1031/tc3_plc_intro/3527777675.html&id=) of variable to be appended to log string.
@@ -348,65 +350,5 @@ END_IF
 _logDataInitialized := FALSE;]]></ST>
       </Implementation>
     </Method>
-    <LineIds Name="TcLog">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.AppendAny">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.AppendString">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.AppendVariable">
-      <LineId Id="86" Count="12" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.Debug">
-      <LineId Id="3" Count="7" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.Error">
-      <LineId Id="3" Count="8" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.Fatal">
-      <LineId Id="3" Count="7" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.Information">
-      <LineId Id="3" Count="7" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.Init">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.InitializeLogData">
-      <LineId Id="3" Count="4" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.OnCondition">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.SetLogger">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.ShortenInstancePath">
-      <LineId Id="3" Count="19" />
-    </LineIds>
-    <LineIds Name="TcLog.ToAdsLog">
-      <LineId Id="3" Count="5" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.ToCustomFormat">
-      <LineId Id="3" Count="7" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLog.Warning">
-      <LineId Id="3" Count="7" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>

--- a/src/TcLogProj/TcLog/Logger/TcLogCore.TcPOU
+++ b/src/TcLogProj/TcLog/Logger/TcLogCore.TcPOU
@@ -12,11 +12,13 @@
 /// automatically if enough memory is available.
 ///
 /// To set the inital buffer size to accomodate 100 messages, use it like this:
-/// ```
+///
+/// ```st
 /// VAR
 ///   myLogger: TcLogCore(BufferSize := 100 * SIZEOF(BYTE) * Tc2_System.MAX_STRING_LENGTH);
 /// END_VAR
 /// ```
+///
 {attribute 'hide_all_locals'}
 FUNCTION_BLOCK TcLogCore IMPLEMENTS ILogCore
 VAR
@@ -462,94 +464,5 @@ _config.FileName := fileName;
 WriteToFile REF= This^;]]></ST>
       </Implementation>
     </Method>
-    <LineIds Name="TcLogCore">
-      <LineId Id="3" Count="0" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.BuildLoggingConfiguration">
-      <LineId Id="3" Count="11" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.Busy.Get">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.Busy.Set">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.Configuration.Get">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.DeleteLogFilesAfterDays">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.Error.Get">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.FB_init">
-      <LineId Id="3" Count="0" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.FB_reinit">
-      <LineId Id="3" Count="0" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.FlushCache">
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.IncludeInstancePath">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.LogCustomFormat">
-      <LineId Id="3" Count="5" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.LogStandardFormat">
-      <LineId Id="64" Count="28" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.MinimumLevel">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.RollingIntervalReached">
-      <LineId Id="3" Count="9" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.RunLogger">
-      <LineId Id="296" Count="1" />
-      <LineId Id="364" Count="0" />
-      <LineId Id="300" Count="1" />
-      <LineId Id="365" Count="0" />
-      <LineId Id="302" Count="46" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.SetDelimiter">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.SetRollingInterval">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.TimestampFormat">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.WriteToAds">
-      <LineId Id="3" Count="3" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
-    <LineIds Name="TcLogCore.WriteToFile">
-      <LineId Id="3" Count="0" />
-      <LineId Id="18" Count="0" />
-      <LineId Id="17" Count="0" />
-      <LineId Id="19" Count="0" />
-      <LineId Id="21" Count="1" />
-      <LineId Id="20" Count="0" />
-      <LineId Id="6" Count="1" />
-      <LineId Id="2" Count="0" />
-    </LineIds>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
Hi @bengeisler,
here is a fix for the documentation-inline st issue. it should be readable way better than before. this tag just commands the documentation parser to show this inline-code segment as structured text format.
Anyway, maybe its a good idea to make some adjustments to your IDE settings in order to have a better ST-git-experience with other contributors. Luckily we also have an open guide for that, and also a youtube video...
Guide: https://doc.zeugwerk.dev/contribute/recom_xae_settings.html
Video: https://youtu.be/Y9lb_3Lmdws
In that video we show some recommendet settings for TcXaeShell and TwinCAT projects when working with ST and OOP.
maybe this helps a little?
Regards
M.