### PR TITLE
doc: optimized struct-entry comments

### DIFF
--- a/src/TcLogProj/TcLog/Logger/_DataTypes/LoggingConfiguration.TcDUT
+++ b/src/TcLogProj/TcLog/Logger/_DataTypes/LoggingConfiguration.TcDUT
@@ -4,26 +4,16 @@
     <Declaration><![CDATA[/// Configuration of TcLogCore
 TYPE LoggingConfiguration :
 STRUCT
-  /// File name where the logs should be written to. Should not include path.
-	FileName : Tc2_System.T_MaxString;
-  /// File path where the logs should be written to. Will be prefixed to `FileName`
-	FilePath : Tc2_System.T_MaxString;
-  /// Whether to include the instance path of TcLog into the log message or not.
-	IncludeInstancePath : BOOL;
-  /// Whether to write the logs to ADS output or not.
-	WriteToAds : BOOL;
-  /// Rolling interval: when to create a new log file.
-	RollingInterval : RollingIntervals;
-  /// What is the minimum log level that gets logged?
-	MinimumLevel : LogLevels;
-  /// Which delimiter should be used between the different parts of the log string?
-	Delimiter : STRING(1);
-  /// When should old log files be deleted? Unit: days. Set it to `0` if log files should never be deleted. 
-	LogFileLifespan : UINT;
-  /// Format of timestamp. See `TcLogCore.TimestampFormat` for formatting options.
-	TimestampFormat : STRING;
+  FileName : Tc2_System.T_MaxString; //< File name where the logs should be written to. Should not include path.
+  FilePath : Tc2_System.T_MaxString; //< File path where the logs should be written to. Will be prefixed to `FileName`
+  IncludeInstancePath : BOOL; //< Whether to include the instance path of TcLog into the log message or not.
+  WriteToAds : BOOL; //< Whether to write the logs to ADS output or not.
+  RollingInterval : RollingIntervals; //< Rolling interval: when to create a new log file.
+  MinimumLevel : LogLevels; //< What is the minimum log level that gets logged?
+  Delimiter : STRING(1); //< Which delimiter should be used between the different parts of the log string? 
+  LogFileLifespan : UINT; //< When should old log files be deleted? Unit: days. Set it to `0` if log files should never be deleted.
+  TimestampFormat : STRING; //< Format of timestamp. See `TcLogCore.TimestampFormat` for formatting options.
 END_STRUCT
-END_TYPE
-]]></Declaration>
+END_TYPE]]></Declaration>
   </DUT>
 </TcPlcObject>


### PR DESCRIPTION
Here is a second PR for struct-comments. (every variable comment, no matter if it is in an VAR_INPUT myVar : BOOL; //< blabla END_VAR or a method should be done in that way. 
These comments should no show up in the description section of your struct-api-doc.

However, it should also work with three / above of the to-be-commented-variable. We are looking into this...