### PR TITLE
fix: path to solution; added references

### DIFF
--- a/.Zeugwerk/config.json
+++ b/.Zeugwerk/config.json
@@ -1,6 +1,6 @@
 {
   "fileversion": 1,
-  "solution": "TcLog.sln",
+  "solution": "src/TcLog.sln",
   "projects": [
     {
       "name": "TcLogProj",
@@ -10,7 +10,16 @@
           "name": "TcLog",
           "type": "Library",
           "frameworks": {},
-          "references": {},
+          "references": {
+            "*": [
+              "Tc2_Standard=*",
+              "Tc2_System=*",
+              "Tc2_Utilities=*",
+              "Tc3_DynamicMemory=*",
+              "Tc3_Modules=*",
+              "Base Interfaces=newest"
+            ]
+          },
           "repositories": [],
           "bindings": {},
           "patches": {

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           username: ${{ secrets.ACTIONS_ZGWK_USERNAME }}
           password: ${{ secrets.ACTIONS_ZGWK_PASSWORD }}
-          filepath: "src/TcLogProj/TcLog/TcLog.plcproj"
+          filepath: "."
           doc-folder: "docs"
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Hi,
here is the fix for your zkdoc problem. the source code to your plc project was moved -> zkdoc does that need to know too. i also added the references in order to be able to build the library eventually later with zkbuild, if you like.
filepath in documentation.yml can be . only, it is only needed if no config.json is provided.
Regards
M.
