### PR TITLE
doc: upgraded to docfx 2.72 modern style

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -21,7 +21,9 @@
     "dest": "html",
     "fileMetadataFiles": [],
     "template": [
-      "statictoc", "template"
+      "default",
+      "modern",
+      "template"
     ],
     "postProcessors": [],
     "markdownEngineName": "markdig",


### PR DESCRIPTION
zkdoc was using an outdated version of docfx and we now upgraded to the latest docfx release, the visual style of the documentation is now a bit fresher when you use the modern theme, see https://stefanbesler.github.io/struckig/

you can also use _appLogoUrl in the file "metadata.json" to add a custom logo for a list of all available meta variables in the modern theme see https://dotnet.github.io/docfx/docs/template.html?tabs=modern 